### PR TITLE
Add Custom State Selector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 node_modules
 dist
 dist_demo
-lib

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ class App extends Component {
 ## Sending notifications
 
 Thanks to Redux, sending notification is simply done by firing an `Action`:
-
+``` javascript
 import { reducer as notifReducer, actions as notifActions, Notifs } from 're-notif';
 const { notifSend } = notifActions;
 
@@ -58,7 +58,7 @@ class Demo extends Component {
     <button onClick={::this.send}>Send</button>
   }
 }
-
+```
 # Demo
 
 [Watch the demo](http://indexiatech.github.io/re-notif) or [checkout its source code](https://github.com/indexiatech/re-notif/blob/master/demo/index.js)
@@ -94,11 +94,15 @@ class Demo extends Component {
 
 > The notification's message.
 
+#### - `stateSelector : Function`
+
+> A custom state selector that will be used by the Redux `connect` function to select the slice of your state tree where you mounted the notifications reducer. Example: `<Notifs stateSelector={ (state) => state.somewhere.notif } />`
+
 ---
 
 ## Reducer
 
-> The notifications reducer, should be mounted under `notifs`.
+> The notifications reducer, should be mounted under `notifs`, unless you provide a `stateSelector` prop to the `<Notifs>` component, in which case the mount point will be determined by the slice of `state` selected.
 
 ---
 

--- a/lib/actions/notifs.js
+++ b/lib/actions/notifs.js
@@ -1,0 +1,51 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+exports.notifSend = notifSend;
+exports.notifDismiss = notifDismiss;
+exports.notifClear = notifClear;
+var NOTIF_SEND = 'NOTIF_SEND';
+exports.NOTIF_SEND = NOTIF_SEND;
+var NOTIF_DISMISS = 'NOTIF_DISMISS';
+exports.NOTIF_DISMISS = NOTIF_DISMISS;
+var NOTIF_CLEAR = 'NOTIF_CLEAR';
+
+exports.NOTIF_CLEAR = NOTIF_CLEAR;
+/**
+ * Publish a notification,
+ * - if `dismissAfter` was set, the notification will be auto dismissed after the given period.
+ * - if id wasn't specified, a time based id will be generated.
+ */
+
+function notifSend(notif) {
+  if (!notif.id) {
+    notif.id = new Date().getTime();
+  }
+  return function (dispatch) {
+    dispatch({ type: NOTIF_SEND, payload: notif });
+
+    if (notif.dismissAfter) {
+      setTimeout(function () {
+        dispatch({ type: NOTIF_DISMISS, payload: notif.id });
+      }, notif.dismissAfter);
+    }
+  };
+}
+
+/**
+ * Dismiss a notification by the given id.
+ */
+
+function notifDismiss(id) {
+  return { type: NOTIF_DISMISS, payload: id };
+}
+
+/**
+ * Clear all notifications
+ */
+
+function notifClear() {
+  return { type: NOTIF_CLEAR };
+}

--- a/lib/components/Notif.js
+++ b/lib/components/Notif.js
@@ -1,0 +1,213 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; desc = parent = undefined; continue _function; } } else if ('value' in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _classnames = require('classnames');
+
+var _classnames2 = _interopRequireDefault(_classnames);
+
+var string = _react.PropTypes.string;
+var func = _react.PropTypes.func;
+var number = _react.PropTypes.number;
+var shape = _react.PropTypes.shape;
+
+/**
+ * A single notification component
+ */
+
+var Notif = (function (_Component) {
+  _inherits(Notif, _Component);
+
+  _createClass(Notif, null, [{
+    key: 'defaultProps',
+    value: {
+      kind: 'info'
+    },
+    enumerable: true
+  }]);
+
+  function Notif() {
+    var _this = this;
+
+    _classCallCheck(this, Notif);
+
+    _get(Object.getPrototypeOf(Notif.prototype), 'constructor', this).call(this);
+
+    this._onActionClick = function (event) {
+      event.preventDefault();
+      if (_this.props.onClick) {
+        _this.props.onActionClick();
+      } else {
+        return;
+      }
+    };
+
+    this._id = new Date().getTime();
+    this._onActionClick = this._onActionClick.bind(this);
+  }
+
+  /*
+   * Handle action click event
+   * @description Handle click events on the
+   */
+
+  _createClass(Notif, [{
+    key: 'render',
+    value: function render() {
+      var _props = this.props;
+      var theme = _props.theme;
+      var kind = _props.kind;
+      var CustomComponent = _props.CustomComponent;
+      var action = _props.action;
+
+      var classes = undefined;
+      var styles = {};
+      if (!theme) {
+        var stylesPerType = stylesNotif[kind];
+        styles = _extends({}, stylesNotif.base, stylesPerType);
+      } else {
+        classes = (0, _classnames2['default'])('re-notif', theme.defaultClasses, theme[kind + 'Classes']);
+      }
+
+      var component = !CustomComponent ? _react2['default'].createElement(
+        'div',
+        { className: classes, style: styles },
+        _react2['default'].createElement(
+          'div',
+          null,
+          _react2['default'].createElement('div', { className: 'notif-icon' }),
+          _react2['default'].createElement(
+            'div',
+            { className: 'notif-content' },
+            _react2['default'].createElement(
+              'span',
+              { className: 'notif-message' },
+              this.props.message
+            )
+          ),
+          action && _react2['default'].createElement(
+            'span',
+            { className: 'notif-action' },
+            _react2['default'].createElement(
+              'button',
+              { onClick: this._onActionClick },
+              this.props.action
+            )
+          ),
+          _react2['default'].createElement('div', { className: 'notif-close' })
+        )
+      ) : _react2['default'].createElement(CustomComponent, this.props);
+
+      return component;
+    }
+  }]);
+
+  return Notif;
+})(_react.Component);
+
+var stylesNotif = {
+  base: {
+    position: 'relative',
+    font: '1rem normal Helvetica, sans-serif',
+    overflow: 'hidden',
+    'borderRadius': 4,
+    'marginBottom': 2,
+    'maxHeight': 400,
+    boxSizing: 'border-box',
+    boxShadow: '0 0 1px 1px rgba(10, 10, 11, .125)',
+    padding: '0.5rem',
+    color: '#fff'
+  },
+
+  success: {
+    backgroundColor: '#64ce83'
+  },
+
+  info: {
+    backgroundColor: '#3ea2ff'
+  },
+
+  warning: {
+    backgroundColor: '#ff7f48'
+  },
+
+  danger: {
+    backgroundColor: '#e74c3c'
+  }
+};
+
+var styleCountdown = {
+  base: {
+    position: 'absolute',
+    bottom: 0,
+    width: 0,
+    height: 4
+  },
+
+  info: {
+    'backgroundColor': '#71bbff'
+  }
+};
+
+Notif.propTypes = {
+  /*
+   * The notification message
+   */
+  message: _react.PropTypes.string.isRequired,
+
+  /**
+   * The message kind to render, this affects the styling of the notification.
+   **/
+  kind: _react2['default'].PropTypes.oneOf(['success', 'info', 'warning', 'danger']).isRequired,
+
+  /*
+   * The given text will be rendered as a button within the notification
+   */
+  action: string,
+
+  onClick: func,
+
+  /*
+   * A handler to be invoked when the action recieves a click event.
+   */
+  onActionClick: func,
+
+  /*
+   * The time in milliseconds that the notification will automatically dismiss after
+   */
+  dismissAfter: number,
+
+  /*
+   * A handler to be invoked upon notification dismiss
+   */
+  onDismis: func,
+
+  theme: shape({
+    defaultClasses: string,
+    successClasses: string,
+    infoClasses: string,
+    warningClasses: string,
+    dangerClasses: string
+  })
+};
+
+exports['default'] = Notif;
+module.exports = exports['default'];

--- a/lib/components/Notifs.js
+++ b/lib/components/Notifs.js
@@ -54,6 +54,8 @@ var Notifs = (function (_Component) {
       var className = _props.className;
       var CustomComponent = _props.CustomComponent;
       var forceNotifsStyles = _props.forceNotifsStyles;
+      var transitionEnterTimeout = _props.transitionEnterTimeout;
+      var transitionLeaveTimeout = _props.transitionLeaveTimeout;
 
       var items = notifs.map(function (notif) {
         return _react2['default'].createElement(_Notif2['default'], { key: getter(notif, 'id'), message: getter(notif, 'message'), kind: getter(notif, 'kind'), theme: theme, CustomComponent: CustomComponent });

--- a/lib/components/Notifs.js
+++ b/lib/components/Notifs.js
@@ -1,0 +1,102 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; desc = parent = undefined; continue _function; } } else if ('value' in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _reactRedux = require('react-redux');
+
+var _reactLibReactCSSTransitionGroup = require('react/lib/ReactCSSTransitionGroup');
+
+var _reactLibReactCSSTransitionGroup2 = _interopRequireDefault(_reactLibReactCSSTransitionGroup);
+
+var _classnames = require('classnames');
+
+var _classnames2 = _interopRequireDefault(_classnames);
+
+var _Notif = require('./Notif');
+
+var _Notif2 = _interopRequireDefault(_Notif);
+
+var getter = function getter(obj, propName) {
+  return obj.get ? obj.get(propName) : obj[propName];
+};
+
+var Notifs = (function (_Component) {
+  _inherits(Notifs, _Component);
+
+  function Notifs() {
+    _classCallCheck(this, Notifs);
+
+    _get(Object.getPrototypeOf(Notifs.prototype), 'constructor', this).apply(this, arguments);
+  }
+
+  _createClass(Notifs, [{
+    key: 'render',
+    value: function render() {
+      var _props = this.props;
+      var notifs = _props.notifs;
+      var theme = _props.theme;
+      var className = _props.className;
+      var CustomComponent = _props.CustomComponent;
+      var forceNotifsStyles = _props.forceNotifsStyles;
+
+      var items = notifs.map(function (notif) {
+        return _react2['default'].createElement(_Notif2['default'], { key: getter(notif, 'id'), message: getter(notif, 'message'), kind: getter(notif, 'kind'), theme: theme, CustomComponent: CustomComponent });
+      });
+
+      var componentStyles = forceNotifsStyles || !theme ? styles : {};
+      return _react2['default'].createElement(
+        'div',
+        { className: (0, _classnames2['default'])('notif-container', className), style: componentStyles },
+        _react2['default'].createElement(
+          _reactLibReactCSSTransitionGroup2['default'],
+          { transitionName: 'notif' },
+          items
+        )
+      );
+    }
+  }], [{
+    key: 'propTypes',
+    value: {
+      theme: _react.PropTypes.object,
+      className: _react.PropTypes.string,
+      CustomComponent: _react.PropTypes.func,
+      forceNotifsStyles: _react.PropTypes.bool,
+      stateSelector: _react.PropTypes.func
+    },
+    enumerable: true
+  }]);
+
+  return Notifs;
+})(_react.Component);
+
+var styles = {
+  position: 'fixed',
+  top: '10px',
+  right: 0,
+  left: 0,
+  zIndex: 1000,
+  width: '80%',
+  maxWidth: 400,
+  margin: 'auto'
+};
+
+exports['default'] = (0, _reactRedux.connect)(function (state, ownProps) {
+  return { notifs: ownProps.stateSelector ? ownProps.stateSelector(state) : state.notifs };
+}, {})(Notifs);
+module.exports = exports['default'];

--- a/lib/components/Notifs.js
+++ b/lib/components/Notifs.js
@@ -65,7 +65,7 @@ var Notifs = (function (_Component) {
         { className: (0, _classnames2['default'])('notif-container', className), style: componentStyles },
         _react2['default'].createElement(
           _reactLibReactCSSTransitionGroup2['default'],
-          { transitionName: 'notif' },
+          { transitionName: 'notif', transitionEnterTimeout: transitionEnterTimeout || 500, transitionLeaveTimeout: transitionLeaveTimeout || 500 },
           items
         )
       );
@@ -77,7 +77,9 @@ var Notifs = (function (_Component) {
       className: _react.PropTypes.string,
       CustomComponent: _react.PropTypes.func,
       forceNotifsStyles: _react.PropTypes.bool,
-      stateSelector: _react.PropTypes.func
+      stateSelector: _react.PropTypes.func,
+      transitionEnterTimeout: _react.PropTypes.number,
+      transitionLeaveTimeout: _react.PropTypes.number
     },
     enumerable: true
   }]);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,25 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj['default'] = obj; return newObj; } }
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+var _reducersNotifs = require('./reducers/notifs');
+
+var _reducersNotifs2 = _interopRequireDefault(_reducersNotifs);
+
+var _actionsNotifs = require('./actions/notifs');
+
+var actions = _interopRequireWildcard(_actionsNotifs);
+
+var _componentsNotifs = require('./components/Notifs');
+
+var _componentsNotifs2 = _interopRequireDefault(_componentsNotifs);
+
+exports.Notifs = _componentsNotifs2['default'];
+exports.actions = actions;
+exports.reducer = _reducersNotifs2['default'];

--- a/lib/reducers/notifs.js
+++ b/lib/reducers/notifs.js
@@ -1,0 +1,31 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+exports['default'] = notifs;
+
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) arr2[i] = arr[i]; return arr2; } else { return Array.from(arr); } }
+
+var _actionsNotifs = require('../actions/notifs');
+
+function notifs(domain, action) {
+  if (domain === undefined) domain = [];
+
+  if (!action || !action.type) return domain;
+
+  switch (action.type) {
+    case _actionsNotifs.NOTIF_SEND:
+      return [action.payload].concat(_toConsumableArray(domain));
+    case _actionsNotifs.NOTIF_DISMISS:
+      return domain.filter(function (notif) {
+        return notif.id !== action.payload;
+      });
+    case _actionsNotifs.NOTIF_CLEAR:
+      return [];
+    default:
+      return domain;
+  }
+}
+
+module.exports = exports['default'];

--- a/package.json
+++ b/package.json
@@ -1,11 +1,19 @@
 {
   "name": "re-notif",
-  "version": "1.0.1",
+  "version": "1.0.4",
   "description": "Redux & React based Notifications center",
   "scripts": {
     "start": "cd demo && node server.js",
-    "build:lib": "BABEL_ENV=production babel src --out-dir lib",
+    "build:lib": "node ./node_modules/better-npm-run build:lib",
     "build:demo": "rimraf ./dist_demo && cd demo && webpack -p && mv dist_demo ../"
+  },
+  "betterScripts": {
+    "build:lib": {
+      "command": "babel src --out-dir lib",
+      "env": {
+        "BABEL_ENV": "production"
+      }
+    }
   },
   "main": "lib/index.js",
   "repository": {
@@ -32,6 +40,7 @@
     "babel-loader": "^5.3.2",
     "babel-plugin-react-transform": "^1.1.1",
     "babel-runtime": "^5.8.25",
+    "better-npm-run": "0.0.5",
     "css-loader": "^0.20.2",
     "eslint-plugin-react": "^3.6.3",
     "express": "^4.13.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "re-notif",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Redux & React based Notifications center",
   "scripts": {
     "start": "cd demo && node server.js",
@@ -30,9 +30,9 @@
     "classnames": "^2.2.0"
   },
   "peerDependencies": {
-    "redux": "^2.0.0 || ^3.0.0",
+    "redux": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "react-redux": "^2.0.0 || ^3.1.0 || ^4.0.0",
-    "react": "^0.13.3 || ^0.14.0"
+    "react": "^0.13.3 || ^0.14.0 || ^15.0"
   },
   "devDependencies": {
     "babel": "^5.8.23",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "re-notif",
-  "version": "1.0.7",
+  "version": "1.0.9",
   "description": "Redux & React based Notifications center",
   "scripts": {
     "start": "cd demo && node server.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "re-notif",
-  "version": "1.0.10",
+  "version": "1.0.12",
   "description": "Redux & React based Notifications center",
   "scripts": {
     "start": "cd demo && node server.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "re-notif",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Redux & React based Notifications center",
   "scripts": {
     "start": "cd demo && node server.js",
@@ -16,6 +16,7 @@
     }
   },
   "main": "lib/index.js",
+  "typings": "./re-notif.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/indexiatech/re-notif.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "re-notif",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Redux & React based Notifications center",
   "scripts": {
     "start": "cd demo && node server.js",
@@ -16,7 +16,6 @@
     }
   },
   "main": "lib/index.js",
-  "typings": "./re-notif.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/indexiatech/re-notif.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "re-notif",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Redux & React based Notifications center",
   "scripts": {
     "start": "cd demo && node server.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "re-notif",
-  "version": "1.0.5",
+  "version": "1.0.7",
   "description": "Redux & React based Notifications center",
   "scripts": {
     "start": "cd demo && node server.js",

--- a/re-notif.d.ts
+++ b/re-notif.d.ts
@@ -1,4 +1,7 @@
-﻿declare module ReNotif {
+﻿///<reference path='../react/react.d.ts' />
+///<reference path='../redux/redux.d.ts' />
+declare module ReNotif {
+    import React = __React;
     interface ThemeProps {
         /**
          * The CSS classes to attach to an info notification.
@@ -48,7 +51,10 @@
          * @default 500
          */
         transitionLeaveTimeout?: number,
-    }    
+    }
+    class Notifs extends React.Component<NotifsProps, {}> {
+        render(): React.DOMElement<any>;
+    }
 
     interface ActionConfig {
         /**
@@ -77,8 +83,8 @@
 }
 
 declare var actions: ReNotif.Actions;
-declare var reducer: any;
-declare var Notifs: any;
+declare var reducer: Redux.Reducer;
+declare var Notifs: typeof ReNotif.Notifs;
 
 declare module 're-notif' {
     export { actions, reducer, Notifs }

--- a/re-notif.d.ts
+++ b/re-notif.d.ts
@@ -1,0 +1,91 @@
+﻿///<reference path='../react/react.d.ts' />
+///<reference path='../redux/redux.d.ts' />
+declare module ReNotif {
+    import React = __React;
+    interface ThemeProps {
+        /**
+         * The CSS classes to attach to an info notification.
+         */
+        infoClasses?: string,
+        /**
+         * The CSS classes to attach to a success notification.
+         */
+        successClasses?: string,
+        /**
+         * The CSS classes to attach to a warning notification.
+         */
+        warningClasses?: string,
+        /**
+         * The CSS classes to attach to a danger notification.
+         */
+        dangerClasses?: string,
+    }
+    interface NotifsProps {
+        className?: string,
+        /**
+         * Set CSS classes to attach to the different kinds of notifications.
+         */
+        theme?: string,
+        /**
+         * Provide a custom component to use for the Notif items.
+         * @see https://github.com/indexiatech/re-notif/blob/master/src/components/Notif.js
+         */
+        CustomComponent?: React.ComponentClass<any>,
+        /**
+         * Whether to force usage of the default `styles`
+         * @see https://github.com/Flavorus/re-notif/blob/custom-state-selector/src/components/Notifs.js#L28
+         */
+        forceNotifsStyles?: boolean,
+        /**
+         * A custom state selector that will be used by the Redux connect function to select the slice of your state tree where you mounted the notifications reducer. 
+         * @example `<Notifs stateSelector={ (state) => state.somewhere.notif } />`
+         */
+        stateSelector?(state): any,
+        /**
+         * React CSSTransitionGroup enter animation timeout
+         * @default 500
+         */
+        transitionEnterTimeout?: number,
+        /**
+         * React CSSTransitionGroup leave animation timeout
+         * @default 500
+         */
+        transitionLeaveTimeout?: number,
+    }
+    class Notifs extends React.Component<NotifsProps, {}> {
+        render(): React.DOMElement<any>;
+    }
+
+    interface ActionConfig {
+        /**
+         * The notification message.
+         */
+        message: string,
+        /**
+         * The notification kind, can be one of: info, success, warning, danger.
+         */
+        kind?: string,
+        /**
+         * Auto dismiss the notification after the given number of milliseconds.
+         */
+        dismissAfter?: number,
+    }
+    interface Actions {
+        /**
+         * Send a notification.
+         */
+        sendNotif(config: ActionConfig): void;
+        /**
+         * Clear all current notifications.
+         */
+        notifClear(): void;
+    }
+}
+
+declare var actions: ReNotif.Actions;
+declare var reducer: Redux.Reducer;
+declare var Notifs: typeof ReNotif.Notifs;
+
+declare module 're-notif' {
+    export { actions, reducer, Notifs }
+}

--- a/re-notif.d.ts
+++ b/re-notif.d.ts
@@ -1,7 +1,4 @@
-﻿///<reference path='../react/react.d.ts' />
-///<reference path='../redux/redux.d.ts' />
-declare module ReNotif {
-    import React = __React;
+﻿declare module ReNotif {
     interface ThemeProps {
         /**
          * The CSS classes to attach to an info notification.
@@ -51,10 +48,7 @@ declare module ReNotif {
          * @default 500
          */
         transitionLeaveTimeout?: number,
-    }
-    class Notifs extends React.Component<NotifsProps, {}> {
-        render(): React.DOMElement<any>;
-    }
+    }    
 
     interface ActionConfig {
         /**
@@ -83,7 +77,7 @@ declare module ReNotif {
 }
 
 declare var actions: ReNotif.Actions;
-declare var reducer: Redux.Reducer;
+declare var reducer: any;
 declare var Notifs: typeof ReNotif.Notifs;
 
 declare module 're-notif' {

--- a/re-notif.d.ts
+++ b/re-notif.d.ts
@@ -78,7 +78,7 @@
 
 declare var actions: ReNotif.Actions;
 declare var reducer: any;
-declare var Notifs: typeof ReNotif.Notifs;
+declare var Notifs: any;
 
 declare module 're-notif' {
     export { actions, reducer, Notifs }

--- a/src/components/Notifs.js
+++ b/src/components/Notifs.js
@@ -12,7 +12,8 @@ class Notifs extends Component {
     theme: PropTypes.object,
     className: PropTypes.string,
     CustomComponent: PropTypes.func,
-    forceNotifsStyles: PropTypes.bool
+    forceNotifsStyles: PropTypes.bool,
+    stateSelector: PropTypes.func
   }
 
   render() {
@@ -47,8 +48,8 @@ const styles = {
 };
 
 export default connect(
-  (state) => {
-    return { notifs: state.get ? state.get('notifs') : state.notifs };
+  (state, ownProps) => {
+    return { notifs: ownProps.stateSelector ? ownProps.stateSelector(state) : state.notifs };
   },
   { }
 )(Notifs);

--- a/src/components/Notifs.js
+++ b/src/components/Notifs.js
@@ -19,7 +19,7 @@ class Notifs extends Component {
   }
 
   render() {
-    const { notifs, theme, className, CustomComponent, forceNotifsStyles} = this.props;
+    const { notifs, theme, className, CustomComponent, forceNotifsStyles, transitionEnterTimeout, transitionLeaveTimeout} = this.props;
 
     const items = notifs.map((notif) => {
       return (

--- a/src/components/Notifs.js
+++ b/src/components/Notifs.js
@@ -13,7 +13,9 @@ class Notifs extends Component {
     className: PropTypes.string,
     CustomComponent: PropTypes.func,
     forceNotifsStyles: PropTypes.bool,
-    stateSelector: PropTypes.func
+    stateSelector: PropTypes.func,
+	transitionEnterTimeout: PropTypes.number,
+	transitionLeaveTimeout: PropTypes.number,
   }
 
   render() {
@@ -28,7 +30,7 @@ class Notifs extends Component {
     const componentStyles = forceNotifsStyles || !theme ? styles : {};
     return (
       <div className={classnames('notif-container', className)} style={componentStyles}>
-        <TransitionGroup transitionName="notif">
+        <TransitionGroup transitionName="notif" transitionEnterTimeout={transitionEnterTimeout || 500} transitionLeaveTimeout={transitionLeaveTimeout || 500}>
           {items}
         </TransitionGroup>
       </div>


### PR DESCRIPTION
Currently, this library assumes that you'll have the notif reducer mounted at "notif" (or you'll have some kind of function like state.get('notif')). This update uses ownProps to allow you to specify a custom stateSelector function, with the signature (state) => state.somewhere.notif
